### PR TITLE
(feat) adds github origin button

### DIFF
--- a/lib/project.js
+++ b/lib/project.js
@@ -49,6 +49,20 @@ module.exports = (function () {
 			return branch;
 		}
 	}, {
+		key: 'origin',
+		get: function get() {
+			var origin;
+			try {
+				var repo = new GitRepository(this.paths[0]);
+				origin = repo.getOriginURL();
+
+				origin = origin.replace(/\/\/(.*)?@/, '//').replace('.git', '');
+				repo.destroy();
+			} catch (_error) {};
+
+			return origin;
+		}
+	}, {
 		key: 'ftpUri',
 		get: function get() {
 			var uri = path.join(this.paths[0], '.ftpconfig');

--- a/lib/recent-projects-view.js
+++ b/lib/recent-projects-view.js
@@ -371,9 +371,12 @@ module.exports = class RecentProjectsView extends ScrollView {
 							"class": 'project-star btn btn-secondary icon icon-star'
 						});
 
-						_this.button({
-							"class": 'project-origin btn btn-secondary icon icon-mark-github'
-						});
+
+						if (project.origin) {
+							_this.button({
+								"class": 'project-origin btn btn-secondary icon icon-mark-github'
+							});
+						}
 
 						// Add a button to remove this project
 						return _this.button({
@@ -428,27 +431,8 @@ module.exports = class RecentProjectsView extends ScrollView {
 	}
 
 	openOrigin(project, entry) {
-		var gitRemote = (
-			`git -C ${project.paths[0]} config --get remote.origin.url`
-		);
-
-		var spawn = require('child_process').spawn;
-		var pid = spawn('sh', ['-c', gitRemote]);
-
-		var remote = '';
-		pid.stdout.on('data', function(chunk) {
-			remote += chunk;
-		});
-
-		pid.on('close', function() {
-			if (!remote) {
-				return;
-			}
-
-			remote = `https://${remote.split('@')[1].split('.git')[0]}`;			
-			var shell = require('shell');
-			shell.openExternal(remote);
-		});
+		var shell = require('shell');
+		shell.openExternal(project.origin);
 	}
 
 	removeProject(project, entry) {

--- a/lib/recent-projects-view.js
+++ b/lib/recent-projects-view.js
@@ -266,6 +266,14 @@ module.exports = class RecentProjectsView extends ScrollView {
 		this.selectedEntry.find('.project-star').click();
 	}
 
+	async originSelected() {
+		if (this.selectedEntry == null) {
+			return;
+		}
+
+		this.selectedEntry.find('.project-origin').click();
+	}
+
 	async removeSelected() {
 		if (this.selectedEntry == null) {
 			return;
@@ -360,7 +368,11 @@ module.exports = class RecentProjectsView extends ScrollView {
 							}
 						});
 						_this.button({
-							"class": 'project-star btn btn-danger icon icon-star'
+							"class": 'project-star btn btn-secondary icon icon-star'
+						});
+
+						_this.button({
+							"class": 'project-origin btn btn-secondary icon icon-mark-github'
 						});
 
 						// Add a button to remove this project
@@ -387,6 +399,10 @@ module.exports = class RecentProjectsView extends ScrollView {
 					ev.stopPropagation();
 					return _this.starProject(project, entry);
 				});
+				entry.find('.project-origin').on('click', function(ev) {
+					ev.stopPropagation();
+					return _this.openOrigin(project, entry);
+				});
 				entry.find('.project-delete').on('click', function(ev) {
 					ev.stopPropagation();
 					return _this.removeProject(project, entry);
@@ -408,6 +424,30 @@ module.exports = class RecentProjectsView extends ScrollView {
 					entry.removeClass('stared');
 				}
 			}
+		});
+	}
+
+	openOrigin(project, entry) {
+		var gitRemote = (
+			`git -C ${project.paths[0]} config --get remote.origin.url`
+		);
+
+		var spawn = require('child_process').spawn;
+		var pid = spawn('sh', ['-c', gitRemote]);
+
+		var remote = '';
+		pid.stdout.on('data', function(chunk) {
+			remote += chunk;
+		});
+
+		pid.on('close', function() {
+			if (!remote) {
+				return;
+			}
+
+			remote = `https://${remote.split('@')[1].split('.git')[0]}`;			
+			var shell = require('shell');
+			shell.openExternal(remote);
 		});
 	}
 

--- a/styles/recent-projects.less
+++ b/styles/recent-projects.less
@@ -61,7 +61,7 @@
     }
     .project-entry.stared {
         .project-star {
-            color: yellow;
+            color: #F19B2C;
         }
     }
     .project-meta {
@@ -80,7 +80,8 @@
         font-size: 150%;
     }
     .project-delete,
-    .project-star {
+    .project-star,
+    .project-origin {
         width: 27px;
         position: absolute;
         top: 10px;
@@ -96,10 +97,14 @@
     .project-star {
         right: 45px;
     }
+    .project-origin {
+        right: 80px;
+    }
     .project-entry:hover,
     .project-entry.selected {
         .project-delete,
-        .project-star {
+        .project-star,
+        .project-origin {
             display: block;
         }
     }


### PR DESCRIPTION
(fix) improves styling and visibility of star button

_Why:_ I've been pretty frustrated with GitHub not having a quick way to jump to the repositories of projects I'm currently/have recently worked on. I'm already using recent-projects to do this at the Atom level, and providing a way to quickly jump to the corresponding GitHub repo is super convenient.