### PR TITLE
fixed: delete button was oddly positioned in Text Only mode

### DIFF
--- a/styles/recent-projects.less
+++ b/styles/recent-projects.less
@@ -136,10 +136,6 @@
             background: transparent;
             color: inherit;
         }
-        .project-delete {
-            top: calc(~"50% - 13.5px");
-            right: 15.5px;
-        }
     }
     .project-meta > * {
         overflow: hidden;


### PR DESCRIPTION
Not sure what the goal of this styling was, but it was making the button look funky

Before:
![image](https://cloud.githubusercontent.com/assets/105934/18234367/7c686aec-72fa-11e6-9482-4841576fcc5d.png)

After:
![image](https://cloud.githubusercontent.com/assets/105934/18234369/83c73c6e-72fa-11e6-9fca-91af1adf5073.png)

Ahh, much better!