### PR TITLE
fixed: attempting to open a project in the current window would often fail and simply close the window

### DIFF
--- a/lib/recent-projects-view.js
+++ b/lib/recent-projects-view.js
@@ -1,5 +1,7 @@
 'use babel';
 
+import AtomProjectUtil from 'atom-project-util'
+
 var atomRef = require('atom'),
 	viewRef = require('atom-space-pen-views'),
 	CompositeDisposable = atomRef.CompositeDisposable,
@@ -449,14 +451,22 @@ module.exports = class RecentProjectsView extends ScrollView {
 	}
 
 	openProject(project) {
-		atom.open({
-			pathsToOpen: project.paths,
-			newWindow: this.newWindow,
-			devMode: project.devMode
-		});
-
-		if (!this.newWindow) {
-			return this.closeAfterOpenProject();
+		if (this.newWindow || project.devMode != atom.inDevMode()) {
+			atom.open({
+				pathsToOpen: project.paths,
+				newWindow: this.newWindow,
+				devMode: project.devMode
+			});
+			this.closeAfterOpenProject();
+		} else {
+			AtomProjectUtil.switch(project.paths)
+				.then(() => {
+					this.closeAfterOpenProject();
+				})
+		    .catch(err => {
+					throw err;
+				})
+			;
 		}
 	}
 

--- a/lib/recent-projects-view.js
+++ b/lib/recent-projects-view.js
@@ -454,7 +454,7 @@ module.exports = class RecentProjectsView extends ScrollView {
 		if (this.newWindow || project.devMode != atom.inDevMode()) {
 			atom.open({
 				pathsToOpen: project.paths,
-				newWindow: this.newWindow,
+				newWindow: true,
 				devMode: project.devMode
 			});
 			this.closeAfterOpenProject();

--- a/lib/recent-projects-view.js
+++ b/lib/recent-projects-view.js
@@ -463,7 +463,7 @@ module.exports = class RecentProjectsView extends ScrollView {
 				.then(() => {
 					this.closeAfterOpenProject();
 				})
-		    .catch(err => {
+				.catch(err => {
 					throw err;
 				})
 			;

--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
   "readmeFile": "README.md",
   "dependencies": {
     "atom-space-pen-views": "^2.0.3",
+    "atom-project-util": "^4.0.0",
     "relative-date": "~>1.1.1"
   }
 }


### PR DESCRIPTION
It seems `atom.open()` is async now, so there's no way to wait on it.
As a result `closeAfterOpenProject()` was firing before it had completed, which if it was opening in the same window would often terminate it before the opening the project had completed.

I've used the https://github.com/mehcode/atom-project-util library which solves this.
Opening projects in the same window now works correctly.