### PR TITLE
fixed: Atom closes/crashes after opening a project from recent projects

### DIFF
--- a/lib/recent-projects-view.js
+++ b/lib/recent-projects-view.js
@@ -498,7 +498,7 @@ module.exports = class RecentProjectsView extends ScrollView {
 			atom.workspace.getActivePane().removeItem(this);
 			atom.commands.dispatch(atom.views.getView(atom.workspace), "tree-view:show");
 		} else {
-			return atom.close();
+			// return atom.close();
 		}
 	}
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "recent-projects",
-  "version": "0.13.1",
+  "version": "0.13.2",
   "main": "./lib/main",
   "description": "Quick access to your recently opened projects",
   "repository": {


### PR DESCRIPTION
This closes #53 